### PR TITLE
Allow templated XLS exports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 5.4
 
 before_script:
-  - git clone -q --depth=1 https://github.com/phalcon/cphalcon.git -b master
+  - git clone -q --depth=1 https://github.com/phalcon/cphalcon.git -b phalcon-v1.3.4
   - (cd cphalcon/ext; export CFLAGS="-g3 -O1 -fno-delete-null-pointer-checks -Wall"; phpize && ./configure --enable-phalcon && make -j4 && sudo make install && phpenv config-add ../unit-tests/ci/phalcon.ini)
   - curl -s http://getcomposer.org/installer | php
   - php composer.phar install --dev

--- a/src/Adapter/AdapterAbstract.php
+++ b/src/Adapter/AdapterAbstract.php
@@ -84,13 +84,19 @@ abstract class AdapterAbstract implements AdapterInterface
     protected function getRenderedView()
     {
         try {
+            /** @var \Phalcon\Mvc\View $view */
             $view = \Phalcon\DI::getDefault()->get('view');
         } catch (\Phalcon\DI\Exception $e) {
             throw new \Vegas\Mvc\Exception;
         }
 
         $view->start();
+
+        $level = $view->getCurrentRenderLevel();
+        $view->setRenderLevel(\Phalcon\Mvc\View::LEVEL_ACTION_VIEW);
         $view->render($this->config->getTemplate(), null);
+        $view->setRenderLevel($level);
+
         $view->finish();
 
         return $view->getContent();

--- a/src/Adapter/AdapterAbstract.php
+++ b/src/Adapter/AdapterAbstract.php
@@ -74,5 +74,26 @@ abstract class AdapterAbstract implements AdapterInterface
         }
         return $values;
     }
+
+    /**
+     * Triggers the rendering process and gets result content as string.
+     * Use only for custom template exports.
+     * @return string
+     * @throws \Vegas\Mvc\Exception
+     */
+    protected function getRenderedView()
+    {
+        try {
+            $view = \Phalcon\DI::getDefault()->get('view');
+        } catch (\Phalcon\DI\Exception $e) {
+            throw new \Vegas\Mvc\Exception;
+        }
+
+        $view->start();
+        $view->render($this->config->getTemplate(), null);
+        $view->finish();
+
+        return $view->getContent();
+    }
 }
 

--- a/src/Adapter/Pdf.php
+++ b/src/Adapter/Pdf.php
@@ -111,26 +111,6 @@ class Pdf extends AdapterAbstract
     }
 
     /**
-     * Triggers the rendering process and gets result content as string
-     * @return string
-     * @throws \Vegas\Mvc\Exception
-     */
-    private function getRenderedView()
-    {
-        try {
-            $view = \Phalcon\DI::getDefault()->get('view');
-        } catch (\Phalcon\DI\Exception $e) {
-            throw new \Vegas\Mvc\Exception;
-        }
-
-        $view->start();
-        $view->render($this->config->getTemplate(), null);
-        $view->finish();
-
-        return $view->getContent();
-    }
-
-    /**
      * Dumps PDF file to memory & retrieves content
      * @param \mPDF $mpdf
      * @return string

--- a/src/Adapter/Xls.php
+++ b/src/Adapter/Xls.php
@@ -39,6 +39,10 @@ class Xls extends AdapterAbstract
      */
     public function output()
     {
+        if ($this->config->getTemplate()) {
+            return $this->getConvertedOutput($this->getRenderedView());
+        }
+
         $data = $this->config->getData();
 
         $xls = new \PHPExcel;
@@ -79,5 +83,15 @@ class Xls extends AdapterAbstract
         $writer = new \PHPExcel_Writer_Excel2007($xls);
         $writer->save('php://output');
         return ob_get_clean();
+    }
+
+    /**
+     * @param string $content UTF-8 string
+     * @return string WINDOWS-1252 encoded string
+     */
+    private function getConvertedOutput($content)
+    {
+        $encoded = iconv('UTF-8', 'WINDOWS-1252//TRANSLIT', $content);
+        return $encoded !== false ? $encoded : $content;
     }
 }

--- a/src/Adapter/Xls.php
+++ b/src/Adapter/Xls.php
@@ -40,7 +40,7 @@ class Xls extends AdapterAbstract
     public function output()
     {
         if ($this->config->getTemplate()) {
-            return $this->getConvertedOutput($this->getRenderedView());
+            return $this->getRenderedView();
         }
 
         $data = $this->config->getData();
@@ -83,15 +83,5 @@ class Xls extends AdapterAbstract
         $writer = new \PHPExcel_Writer_Excel2007($xls);
         $writer->save('php://output');
         return ob_get_clean();
-    }
-
-    /**
-     * @param string $content UTF-8 string
-     * @return string WINDOWS-1252 encoded string
-     */
-    private function getConvertedOutput($content)
-    {
-        $encoded = iconv('UTF-8', 'WINDOWS-1252//TRANSLIT', $content);
-        return $encoded !== false ? $encoded : $content;
     }
 }

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -45,7 +45,6 @@ class ExporterTest extends TestCase
         ];
 
         return (new \Vegas\Exporter\ExportSettings)
-            ->setTemplate('export_sample')
             ->setFilename('test_export_file')
             ->setOutputDir('/tmp')
             ->setTitle('Sample file export') // optional
@@ -150,6 +149,7 @@ class ExporterTest extends TestCase
     public function testPrintAndDownloadPdf()
     {
         $config = $this->createExportConfig();
+        $config->setTemplate('export_sample');
 
         $this->exporter->setConfig($config);
 
@@ -175,6 +175,23 @@ class ExporterTest extends TestCase
 
         $this->assertNotEmpty($printBuffer);
         $this->assertNotEmpty($downloadBuffer);
+    }
+
+    public function testPrintAndDownloadTemplatedXls()
+    {
+        $config = $this->createExportConfig();
+        $config->setTemplate('export_sample');
+
+        $this->exporter->setConfig($config);
+
+        $printBuffer = $this->exporter->printXls();
+        ob_start();
+        $this->exporter->downloadXls();
+        $downloadBuffer = ob_get_clean();
+
+        $this->assertNotEmpty($printBuffer);
+        $this->assertNotEmpty($downloadBuffer);
+        $this->assertEquals($printBuffer, $downloadBuffer);
     }
 
     public function testPrintAndDownloadXml()
@@ -222,14 +239,16 @@ class ExporterTest extends TestCase
         $this->exporter->saveCsv();
         $this->assertFileExists($this->getTestFilePath('.csv'));
 
-        $this->exporter->savePdf();
-        $this->assertFileExists($this->getTestFilePath('.pdf'));
-
+        $config->setTemplate('export_sample');
         $this->exporter->saveXls();
         $this->assertFileExists($this->getTestFilePath('.xls'));
 
         $this->exporter->saveXml();
         $this->assertFileExists($this->getTestFilePath('.xml'));
+
+        $config->setTemplate('export_sample');
+        $this->exporter->savePdf();
+        $this->assertFileExists($this->getTestFilePath('.pdf'));
 
         try {
             $this->exporter->saveNothing();

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -180,7 +180,7 @@ class ExporterTest extends TestCase
     public function testPrintAndDownloadTemplatedXls()
     {
         $config = $this->createExportConfig();
-        $config->setTemplate('export_sample');
+        $config->setTemplate('xls_export_sample');
 
         $this->exporter->setConfig($config);
 
@@ -239,7 +239,6 @@ class ExporterTest extends TestCase
         $this->exporter->saveCsv();
         $this->assertFileExists($this->getTestFilePath('.csv'));
 
-        $config->setTemplate('export_sample');
         $this->exporter->saveXls();
         $this->assertFileExists($this->getTestFilePath('.xls'));
 

--- a/tests/fixtures/app/modules/Test/views/xls_export_sample.volt
+++ b/tests/fixtures/app/modules/Test/views/xls_export_sample.volt
@@ -1,0 +1,23 @@
+<html>
+<head>
+    {# Charset is required in order to keep valid import inside Excel/Calc #}
+    <meta http-equiv=Content-Type content="text/html; charset=utf-8">
+</head>
+<body>
+    {% set export = exporter.getConfig() %}
+    <table style="width: 100%; border: 2px solid #000; border-collapse: collapse;">
+        <tr>
+            {% for header in export.getHeaders() %}
+                <th style="border: 2px solid #000;">{{ header }}</th>
+            {% endfor %}
+        </tr>
+        {% for item in export.getData() %}
+            <tr>
+                {% for value in item %}
+                    <td style="border: 2px solid #000;">{{ value }}</td>
+                {% endfor %}
+            </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>


### PR DESCRIPTION
- XLS exports can now use .volt template to render complete output file when template is provided in config.
- Fixed issue with rendering due to invalid level
